### PR TITLE
feat: Actualizar mensaje de error en logout para mayor claridad

### DIFF
--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -84,7 +84,7 @@ class AuthService
     } catch (\Exception $e) {
       DB::rollBack();
       Log::error($e->getMessage());
-      throw new ApiException(__('i18n.logout_user_ko'), 500);
+      throw new ApiException(__('i18n.logout_ko'), 500);
     }
   }
 }


### PR DESCRIPTION
- Se cambió el mensaje de error lanzado en el método logout.
- Se utilizó una clave de traducción más adecuada para el mensaje de error.